### PR TITLE
Concordance fixes: paginate before sorting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "atap_widgets"
-version = "0.1.12"
+version = "0.1.13"
 description = "Interactive widgets used by the Australian Text Analytics Platform"
 authors = ["Marius Mather <marius.mather@sydney.edu.au>"]
 license = "MIT"

--- a/src/atap_widgets/concordance.py
+++ b/src/atap_widgets/concordance.py
@@ -391,6 +391,16 @@ class ConcordanceTable:
         results_df.reset_index(inplace=True)
         # Reorder columns
         results_df = results_df[["text_id", "left_context", "match", "right_context"]]
+        # Sort
+        if self.sort == "text_id":
+            results_df = results_df.sort_values(by="text_id")
+        elif self.sort in ("left_context", "right_context"):
+            results_df = self.sort_by_context(results_df, context=self.sort)
+        else:
+            raise ValueError(
+                f"Invalid sort value {self.sort}: should be 'text_id',"
+                " 'left_context' or 'right_context'"
+            )
         return results_df
 
     def _get_total_pages(self, n_results: int) -> int:
@@ -432,16 +442,6 @@ class ConcordanceTable:
             results = results.iloc[start_index:end_index]
         except NoResultsError:
             return "No results found. Try a different search term"
-
-        if self.sort == "text_id":
-            results = results.sort_values(by="text_id")
-        elif self.sort in ("left_context", "right_context"):
-            results = self.sort_by_context(results, context=self.sort)
-        else:
-            raise ValueError(
-                f"Invalid sort value {self.sort}: should be 'text_id',"
-                " 'left_context' or 'right_context'"
-            )
 
         return self._get_table_html(results, n_total=n_total)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,3 +61,14 @@ def sherlock_holmes_dummy_conversation(sherlock_holmes_dummy_df):
     in a conversation, for checking contingency counts etc.
     """
     return Conversation(sherlock_holmes_dummy_df)
+
+
+@pytest.fixture
+def sortable_text_df():
+    df = pd.DataFrame(
+        {
+            "text": ["The pen is red", "My pen is green", "Your pen is blue"],
+            "text_id": [1, 2, 3],
+        }
+    )
+    return df

--- a/tests/test_concordance.py
+++ b/tests/test_concordance.py
@@ -46,3 +46,22 @@ def test_text_search_regex():
     table = ConcordanceTable(df, keyword=r"^[ACGT]+$", regex=True)
     results = table.to_dataframe()
     assert (results["text_id"] == [1, 4]).all()
+
+
+def test_sorting(sortable_text_df):
+    df = prepare_text_df(sortable_text_df, id_column="text_id")
+    table = ConcordanceTable(df, keyword="pen", sort="text_id")
+
+    # text_id/default sort: original order
+    text_id_sorted = table.to_dataframe()
+    assert (text_id_sorted["text_id"] == [1, 2, 3]).all()
+
+    # Left context sort: My, The, Your should be 2, 1, 3
+    table.sort = "left_context"
+    left_context_sorted = table.to_dataframe()
+    assert (left_context_sorted["text_id"] == [2, 1, 3]).all()
+
+    # Right context sort: blue, green, red should be 3, 2, 1
+    table.sort = "right_context"
+    right_context_sorted = table.to_dataframe()
+    assert (right_context_sorted["text_id"] == [3, 2, 1]).all()


### PR DESCRIPTION
I noticed we were getting incorrect results when sorting by left or right context, because we sorted after paginating the results. This should be fixed now. Have added an initial test of sorting behaviour (although it doesn't test pagination yet).