### PR TITLE
Optimize/speed up co-occurrence counting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "atap_widgets"
-version = "0.2.7"
+version = "0.2.8"
 description = "Interactive widgets used by the Australian Text Analytics Platform"
 authors = ["Marius Mather <marius.mather@sydney.edu.au>"]
 license = "MIT"


### PR DESCRIPTION
This seems to be the slowest part of the similarity calculation code, makes sense as it has to do some operations with all pairs of terms.