### PR TITLE
searched numbers get confused with tags

### DIFF
--- a/src/atap_widgets/concordance.py
+++ b/src/atap_widgets/concordance.py
@@ -608,7 +608,11 @@ class ConcordanceTable:
         results_df = results_df[["text_id", "left_context", "match", "right_context"]]
 
         # Could Ancor ContextLines somewhere here if the class is properly integrated
-
+        
+        # searching numbers may inadvertently bring up tagged line matches leaving no left context
+        # remove if this is the case
+        results_df = results_df[results_df.left_context.str.contains('--')] 
+        
         if self.stylingOn:
             # Extract Line number tag from original un-grouped dataframe
             results_df = results_df.assign(


### PR DESCRIPTION
making sure when searching for numbers, that the tagged lines hidden in the mechanics get excluded from the search matches